### PR TITLE
Define Logger virtual constructor and function

### DIFF
--- a/include/rocksdb/env.h
+++ b/include/rocksdb/env.h
@@ -889,7 +889,7 @@ class Logger {
 
   explicit Logger(const InfoLogLevel log_level = InfoLogLevel::INFO_LEVEL)
       : closed_(false), log_level_(log_level) {}
-  virtual ~Logger();
+  virtual ~Logger() {}
 
   // Close the log file. Must be called before destructor. If the return
   // status is NotSupported(), it means the implementation does cleanup in
@@ -913,7 +913,7 @@ class Logger {
   // of *this (see @SetInfoLogLevel and @GetInfoLogLevel) will not be
   // printed.
   virtual void Logv(const InfoLogLevel log_level, const char* format,
-                    va_list ap);
+                    va_list ap) = 0;
 
   virtual size_t GetLogFileSize() const { return kDoNotSupportGetLogFileSize; }
   // Flush to the OS buffers


### PR DESCRIPTION
When I create my own implementation of Logger, 
and try to link it into my executable, I get the error

```
undefined reference to `typeinfo for rocksdb::Logger'
```

I am using rocksdb built in release mode, which seemingly
is built with no RTTI. I got it by calling
`sudo apt-get install librocksdb-dev`.

This change allows folks using such release builds
to successfully link their applications.

It is similar to #3008